### PR TITLE
Scaled hsv

### DIFF
--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -44,6 +44,13 @@ def IntToHsv(intValue):
     """ Convert an FL Studio Color Value (Int) to HSV """
     return(RgbToHsv(IntToRGB(intValue)))
 
+def IntToRGB(intValue):
+    """ Convert an FL Studio Color Value (Int) to RGB """
+    blue = intValue & 255
+    green = (intValue >> 8) & 255
+    red = (intValue >> 16) & 255
+    return (red, green, blue)
+
 def RgbToHsv(rgb):
     R, G, B = rgb
     R, G, B = R / 255.0, G / 255.0, B / 255.0

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -85,16 +85,16 @@ def RgbToHsv(rgb):
     delta = max_rgb - min_rgb # 255-20 = 235
 
     V = max_rgb  # Value 255
-    S = 0 if max_rgb == 0 else delta / max_rgb  # Saturation 235/255 S = 0.922
+    S = 0 if max_rgb == 0 else delta // max_rgb  # Saturation 235/255 S = 0.922
 
     if delta == 0:
         H = 0  # Hue
     elif max_rgb == R:
-        H = 60 * (((G - B) / delta) % 6) # (((167-20) / 235) % 6 ) == 1 and 1x60 is 60
+        H = 0 + 43*(G - B)//delta
     elif max_rgb == G:
-        H = 60 * (((B - R) / delta) + 2)
+        H = 85 + 43*(B - R)//delta
     elif max_rgb == B:
-        H = 60 * (((R - G) / delta) + 4)
+        H = 171 + 43*(R - G)//delta
 
     # Scaling H, S, and V to the 0-255 range
     H = int(H / 360 * 255)

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -15,13 +15,13 @@ Value = 2
 def GetMcuColor(intValue):
     """ Get the MCU Screen Color code from an Int value (FL Studio Color Value) """
     c_hsv = IntToHsv(intValue)
-    
+
     # Define color mapping table
     color_ranges = [
-        (0, 79, ScreenColorYellow),
-        (80, 119, ScreenColorGreen),
+        (0, 69, ScreenColorYellow),
+        (70, 119, ScreenColorGreen),
         (120, 149, ScreenColorCyan),
-        (150, 169, ScreenColorBlue),
+        (150, 199, ScreenColorBlue),
         (200, 350, ScreenColorPurple),
         (351, 399, ScreenColorRed)
     ]

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -22,7 +22,8 @@ def GetMcuColor(intValue):
         (51, 117, ScreenColorGreen),
         (118, 140, ScreenColorCyan),
         (141, 190, ScreenColorBlue),
-        (191, 241, ScreenColorPurple)
+        (191, 241, ScreenColorPurple),
+        (242, 255, ScreenColorRed)
     ]
 
     # Check for special cases

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -78,16 +78,15 @@ def IntToRGB(intValue):
 def RgbToHsv(rgb):
     """ Converts an RGB tuple (value range from 0 to 255) to an HSV tuple """
     R, G, B = rgb
-    R, G, B = R / 255.0, G / 255.0, B / 255.0
 
     max_rgb = max(R, G, B)  # R = 255
     min_rgb = min(R, G, B)  # B = 20
-    delta = max_rgb - min_rgb # 255-20 = 235
+    delta = int(max_rgb - min_rgb) # 255-20 = 235
 
     V = max_rgb  # Value 255
-    S = 0 if V == 0 else 255 * delta // V  # Saturation 235/255 S = 0.922
+    H = S = 0 if V == 0 else 255 * delta // V  # Saturation 235/255 S = 0.922
 
-    if delta == 0:
+    if S == 0:
         H = 0  # Hue
     elif max_rgb == R:
         H = 0 + 43*(G - B)//delta

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -85,7 +85,7 @@ def RgbToHsv(rgb):
     delta = max_rgb - min_rgb # 255-20 = 235
 
     V = max_rgb  # Value 255
-    S = 0 if max_rgb == 0 else delta // max_rgb  # Saturation 235/255 S = 0.922
+    S = 0 if V == 0 else 255 * delta // V  # Saturation 235/255 S = 0.922
 
     if delta == 0:
         H = 0  # Hue
@@ -95,10 +95,5 @@ def RgbToHsv(rgb):
         H = 85 + 43*(B - R)//delta
     elif max_rgb == B:
         H = 171 + 43*(R - G)//delta
-
-    # Scaling H, S, and V to the 0-255 range
-    H = int(H / 360 * 255)
-    S = int(S * 255)
-    V = int(V * 255)
 
     return (H, S, V)

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -22,8 +22,8 @@ def GetMcuColor(intValue):
         (70, 119, ScreenColorGreen),
         (120, 149, ScreenColorCyan),
         (150, 199, ScreenColorBlue),
-        (200, 350, ScreenColorPurple),
-        (351, 399, ScreenColorRed)
+        (200, 309, ScreenColorPurple),
+        (310, 399, ScreenColorRed)
     ]
 
     if c_hsv[Value] > 30 and c_hsv[Saturation] > 40:

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -84,10 +84,10 @@ def RgbToHsv(rgb):
     delta = int(max_rgb - min_rgb) # 255-20 = 235
 
     V = max_rgb  # Value 255
-    H = S = 0 if V == 0 else 255 * delta // V  # Saturation 235/255 S = 0.922
+    S = 0 if V == 0 else (255 * delta) // V  # Saturation 235/255 S = 0.922
 
     if S == 0:
-        H = 0  # Hue
+        H = 0
     elif max_rgb == R:
         H = 0 + 43*(G - B)//delta
     elif max_rgb == G:

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -80,17 +80,17 @@ def RgbToHsv(rgb):
     R, G, B = rgb
     R, G, B = R / 255.0, G / 255.0, B / 255.0
 
-    max_rgb = max(R, G, B)
-    min_rgb = min(R, G, B)
-    delta = max_rgb - min_rgb
+    max_rgb = max(R, G, B)  # R = 255
+    min_rgb = min(R, G, B)  # B = 20
+    delta = max_rgb - min_rgb # 255-20 = 235
 
-    V = max_rgb  # Value
-    S = 0 if max_rgb == 0 else delta / max_rgb  # Saturation
+    V = max_rgb  # Value 255
+    S = 0 if max_rgb == 0 else delta / max_rgb  # Saturation 235/255 S = 0.922
 
     if delta == 0:
         H = 0  # Hue
     elif max_rgb == R:
-        H = 60 * (((G - B) / delta) % 6)
+        H = 60 * (((G - B) / delta) % 6) # (((167-20) / 235) % 6 ) == 1 and 1x60 is 60
     elif max_rgb == G:
         H = 60 * (((B - R) / delta) + 2)
     elif max_rgb == B:

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -16,20 +16,14 @@ def GetMcuColor(intValue):
     """ Get the MCU Screen Color code from an Int value (FL Studio Color Value) """
     c_hsv = IntToHsv(intValue)
     
-    if c_hsv[Hue] < 0:
-        thue = c_hsv[Hue]*-1
-        thue = (255-thue)
-        c_hsv = (thue, c_hsv[Saturation], c_hsv[Value])
-
     # Define color mapping table
     color_ranges = [
-        (0, 28, ScreenColorRed),
-        (29, 50, ScreenColorYellow),
-        (51, 117, ScreenColorGreen),
-        (118, 140, ScreenColorCyan),
-        (141, 190, ScreenColorBlue),
-        (191, 236, ScreenColorPurple),
-        (237, 255, ScreenColorRed)
+        (0, 79, ScreenColorYellow),
+        (80, 119, ScreenColorGreen),
+        (120, 149, ScreenColorCyan),
+        (150, 169, ScreenColorBlue),
+        (200, 350, ScreenColorPurple),
+        (351, 399, ScreenColorRed)
     ]
 
     if c_hsv[Value] > 30 and c_hsv[Saturation] > 40:
@@ -50,57 +44,27 @@ def IntToHsv(intValue):
     """ Convert an FL Studio Color Value (Int) to HSV """
     return(RgbToHsv(IntToRGB(intValue)))
 
-def IntToRGB(intValue):
-    """ Convert an FL Studio Color Value (Int) to RGB """
-    blue = intValue & 255
-    green = (intValue >> 8) & 255
-    red = (intValue >> 16) & 255
-    return (red, green, blue)
-
-    """
-    Converts an RGB color value to HSV.
-
-    This function transforms a color value from the RGB (Red, Green, Blue) color space 
-    to the HSV (Hue, Saturation, Value) color space. The input RGB values are 
-    expected to be in the range of 0 to 255. The function normalizes these values to 
-    the range 0-1 for internal calculations and then scales the resulting HSV values 
-    back to the 0-255 range.
-
-    Parameters:
-    rgb (tuple): A tuple of three integers representing the Red, Green, and Blue 
-                 components of the color. Each value should be in the range 0-255.
-
-    Returns:
-    tuple: A tuple of three integers representing the Hue, Saturation, and Value 
-           components of the color in the HSV color space. Hue is scaled to fit 
-           within 0-255 (originally it is defined in degrees from 0-360), and 
-           both Saturation and Value are in the range 0-255.
-
-    The Hue (H) calculation is done based on which RGB component is the maximum.
-    If there's no dominant color (i.e., all RGB values are equal), Hue is set to zero.
-    Saturation (S) is computed as the ratio of the difference between the maximum and
-    minimum RGB values to the maximum RGB value. If the maximum RGB value is zero,
-    Saturation is set to zero to avoid division by zero. Value (V) is simply the maximum
-    of the RGB components.
-    """
 def RgbToHsv(rgb):
-    """ Converts an RGB tuple (value range from 0 to 255) to an HSV tuple """
     R, G, B = rgb
+    R, G, B = R / 255.0, G / 255.0, B / 255.0
 
-    max_rgb = max(rgb)  # R = 255
-    min_rgb = min(rgb)  # B = 20
-    delta = int(max_rgb - min_rgb) # 255-20 = 235
+    max_rgb = max(R, G, B)
+    min_rgb = min(R, G, B)
+    delta = max_rgb - min_rgb
 
-    V = max_rgb  # Value 255
-    S = 0 if V == 0 else (255 * delta) // V  # Saturation 235/255 S = 0.922
+    V = max_rgb  # Value
+    S = 0 if max_rgb == 0 else (delta / max_rgb)  # Saturation
 
-    if S == 0:
-        H = 0
+    if delta == 0:
+         H = 0  # Hue
     elif max_rgb == R:
-        H = int(0 + 43*(G - B)//delta)
+        H = 60 * (((G - B) / delta) % 6)
     elif max_rgb == G:
-        H = int(85 + 43*(B - R)//delta)
-    else:
-        H = int(171 + 43*(R - G)//delta)
+        H = 85 + 43 * (B-R)/delta
+    elif max_rgb == B:
+        H = 171 + 43 * (R-G)/delta
 
-    return (H, S, V)
+    S = int(S * 255)
+    V = int(V * 255)
+
+    return (int(H), int(S), int(V))

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -26,16 +26,17 @@ def GetMcuColor(intValue):
         (242, 255, ScreenColorRed)
     ]
 
+    if c_hsv[2] > 30 and c_hsv[1] > 40:
+        # Find color based on hue value
+        for start, end, color in color_ranges:
+            if start <= c_hsv[0] <= end:
+                return color
+
     # Check for special cases
     if c_hsv[2] < 30:
         return ScreenColorBlack
     if c_hsv[2] > 138 or c_hsv[1] < 40:
         return ScreenColorWhite
-
-    # Find color based on hue value
-    for start, end, color in color_ranges:
-        if start <= c_hsv[0] <= end:
-            return color
 
     return ScreenColorWhite
 

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -8,14 +8,18 @@ ScreenColorPurple = 0x05
 ScreenColorCyan = 0x06
 ScreenColorWhite = 0x07
 
+Hue = 0
+Saturation = 1
+Value = 2
+
 def GetMcuColor(intValue):
     """ Get the MCU Screen Color code from an Int value (FL Studio Color Value) """
     c_hsv = IntToHsv(intValue)
     
-    if c_hsv[0] < 0:
-        thue = c_hsv[0]*-1
+    if c_hsv[Hue] < 0:
+        thue = c_hsv[Hue]*-1
         thue = (255-thue)
-        c_hsv = (thue, c_hsv[1], c_hsv[2])
+        c_hsv = (thue, c_hsv[Saturation], c_hsv[Value])
 
     # Define color mapping table
     color_ranges = [
@@ -28,16 +32,16 @@ def GetMcuColor(intValue):
         (237, 255, ScreenColorRed)
     ]
 
-    if c_hsv[2] > 30 and c_hsv[1] > 40:
+    if c_hsv[Value] > 30 and c_hsv[Saturation] > 40:
         # Find color based on hue value
         for start, end, color in color_ranges:
-            if start <= c_hsv[0] <= end:
+            if start <= c_hsv[Hue] <= end:
                 return color
 
     # Check for special cases
-    if c_hsv[2] < 30:
+    if c_hsv[Value] < 30:
         return ScreenColorBlack
-    if c_hsv[2] > 138 or c_hsv[1] < 40:
+    if c_hsv[Value] > 138 or c_hsv[Saturation] < 40:
         return ScreenColorWhite
 
     return ScreenColorWhite

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -13,7 +13,9 @@ def GetMcuColor(intValue):
     c_hsv = IntToHsv(intValue)
     
     if c_hsv[0] < 0:
-        c_hsv = (c_hsv[0] * -1, c_hsv[1], c_hsv[2])
+        thue = c_hsv[0]*-1
+        thue = (255-thue)
+        c_hsv = (thue, c_hsv[1], c_hsv[2])
 
     # Define color mapping table
     color_ranges = [
@@ -22,8 +24,8 @@ def GetMcuColor(intValue):
         (51, 117, ScreenColorGreen),
         (118, 140, ScreenColorCyan),
         (141, 190, ScreenColorBlue),
-        (191, 241, ScreenColorPurple),
-        (242, 255, ScreenColorRed)
+        (191, 236, ScreenColorPurple),
+        (237, 255, ScreenColorRed)
     ]
 
     if c_hsv[2] > 30 and c_hsv[1] > 40:

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -75,33 +75,33 @@ def IntToRGB(intValue):
     Saturation is set to zero to avoid division by zero. Value (V) is simply the maximum
     of the RGB components.
     """
-def RgbToHsv(rgb):
-    """ Converts an RGB tuple (value range from 0 to 255) to an HSV tuple """
-    R, G, B = rgb
-    R = max(250, R)
-    G = max(250, G)
-    B = max(250, B)
-    R, G, B = R / 255.0, G / 255.0, B / 255.0
+def RgbToHsv(RGB):
+    r,g,b = RGB
 
-    max_rgb = max(R, G, B)
-    min_rgb = min(R, G, B)
-    delta = max_rgb - min_rgb
+    maxc = max(r, g, b)
+    minc = min(r, g, b)
 
-    V = max_rgb  # Value
-    S = 0 if max_rgb == 0 else delta / max_rgb  # Saturation
+    # HSV: Hue, Saturation, Value
+    # H: position in the spectrum
+    # S: color saturation ("purity")
+    # V: color brightness
+    
+    v = maxc
+    if minc == maxc:
+        return 0.0, 0.0, v
 
-    if delta == 0:
-        H = 0  # Hue
-    elif max_rgb == R:
-        H = 60 * (((G - B) / delta) % 6)
-    elif max_rgb == G:
-        H = 60 * (((B - R) / delta) + 2)
-    elif max_rgb == B:
-        H = 60 * (((R - G) / delta) + 4)
+    s = (maxc-minc) / maxc
+    rc = (maxc-r) / (maxc-minc)
+    gc = (maxc-g) / (maxc-minc)
+    bc = (maxc-b) / (maxc-minc)
+    
+    if r == maxc:
+        h = bc-gc
+    elif g == maxc:
+        h = 2.0+rc-bc
+    else:
+        h = 4.0+gc-rc
 
-    # Scaling H, S, and V to the 0-255 range
-    H = int(H / 360 * 255)
-    S = int(S * 255)
-    V = int(V * 255)
-
-    return (H, S, V)
+    h = (h/6.0) % 1.0
+    
+    return h, s, v

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -78,6 +78,9 @@ def IntToRGB(intValue):
 def RgbToHsv(rgb):
     """ Converts an RGB tuple (value range from 0 to 255) to an HSV tuple """
     R, G, B = rgb
+    R = max(250, R)
+    G = max(250, G)
+    B = max(250, B)
     R, G, B = R / 255.0, G / 255.0, B / 255.0
 
     max_rgb = max(R, G, B)

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -79,8 +79,8 @@ def RgbToHsv(rgb):
     """ Converts an RGB tuple (value range from 0 to 255) to an HSV tuple """
     R, G, B = rgb
 
-    max_rgb = max(R, G, B)  # R = 255
-    min_rgb = min(R, G, B)  # B = 20
+    max_rgb = max(rgb)  # R = 255
+    min_rgb = min(rgb)  # B = 20
     delta = int(max_rgb - min_rgb) # 255-20 = 235
 
     V = max_rgb  # Value 255
@@ -92,7 +92,7 @@ def RgbToHsv(rgb):
         H = 0 + 43*(G - B)//delta
     elif max_rgb == G:
         H = 85 + 43*(B - R)//delta
-    elif max_rgb == B:
+    else:
         H = 171 + 43*(R - G)//delta
 
     return (H, S, V)

--- a/mcu_colors.py
+++ b/mcu_colors.py
@@ -89,10 +89,10 @@ def RgbToHsv(rgb):
     if S == 0:
         H = 0
     elif max_rgb == R:
-        H = 0 + 43*(G - B)//delta
+        H = int(0 + 43*(G - B)//delta)
     elif max_rgb == G:
-        H = 85 + 43*(B - R)//delta
+        H = int(85 + 43*(B - R)//delta)
     else:
-        H = 171 + 43*(R - G)//delta
+        H = int(171 + 43*(R - G)//delta)
 
     return (H, S, V)

--- a/test_colormap.py
+++ b/test_colormap.py
@@ -1,0 +1,31 @@
+import unittest
+from mcu_colors import GetMcuColor,ScreenColorBlack,ScreenColorRed,ScreenColorGreen,ScreenColorYellow,ScreenColorBlue,ScreenColorPurple,ScreenColorCyan,ScreenColorWhite 
+
+# test specific code to pack rgb back into int
+def RgbToInt(rgb):
+    R,G,B = rgb
+    int_value = ((R&255) << 16)
+    int_value |= ((G&255) << 8)
+    int_value |= (B&255)
+    return int_value
+
+class TestGetMcuColor(unittest.TestCase):
+    
+    def test_black(self):
+        self.assertEqual(GetMcuColor(RgbToInt((0, 0, 0))), ScreenColorBlack)
+
+    def test_white(self):
+        self.assertEqual(GetMcuColor(RgbToInt((255, 255, 255))), ScreenColorWhite)
+
+    def test_custom_color(self):
+        # Add a test for a custom RGB color
+        self.assertEqual(GetMcuColor(RgbToInt((int(229), int(229), int(21)))), ScreenColorYellow)  # yellow
+        self.assertEqual(GetMcuColor(RgbToInt((int(26), int(255), int(55)))), ScreenColorGreen)  # green
+        self.assertEqual(GetMcuColor(RgbToInt((int(94), int(154), int(174)))), ScreenColorCyan)  # cyan
+        self.assertEqual(GetMcuColor(RgbToInt((int(13), int(64), int(148)))), ScreenColorBlue) # blue
+        self.assertEqual(GetMcuColor(RgbToInt((int(109), int(22), int(98)))), ScreenColorPurple)  # purple
+        self.assertEqual(GetMcuColor(RgbToInt((int(255), int(20), int(32)))), ScreenColorRed)  # red
+
+# This allows running the tests from the command line
+if __name__ == '__main__':
+    unittest.main()

--- a/test_mcu_colors.py
+++ b/test_mcu_colors.py
@@ -1,0 +1,32 @@
+import unittest
+from mcu_colors import RgbToHsv
+
+class TestRgbToHsv(unittest.TestCase):
+    
+    def test_black(self):
+        self.assertEqual(RgbToHsv((0, 0, 0)), (0, 0, 0))
+
+    def test_white(self):
+        self.assertEqual(RgbToHsv((255, 255, 255)), (0, 0, 255))
+
+    def test_red(self):
+        self.assertEqual(RgbToHsv((255, 0, 0)), (0, 255, 255))
+
+    def test_green(self):
+        self.assertEqual(RgbToHsv((0, 255, 0)), (85, 255, 255))
+
+    def test_blue(self):
+        self.assertEqual(RgbToHsv((0, 0, 255)), (171, 255, 255))
+
+    def test_custom_color(self):
+        # Add a test for a custom RGB color
+        self.assertEqual(RgbToHsv((int(229), int(229), int(21))), (60, 231, 229))  # yellow
+        self.assertEqual(RgbToHsv((int(26), int(255), int(55))), (90, 229, 255))  # green
+        self.assertEqual(RgbToHsv((int(94), int(154), int(174))), (138, 117, 174))  # cyan
+        self.assertEqual(RgbToHsv((int(13), int(64), int(148))), (154, 232, 148)) # blue
+        self.assertEqual(RgbToHsv((int(109), int(22), int(98))), (307, 203, 109))  # purple
+        self.assertEqual(RgbToHsv((int(255), int(20), int(32))), (356, 235, 255))  # red
+
+# This allows running the tests from the command line
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Noticed there was a fundamental issue with the RgbToHsv transform that resulted in wrapping the hue value (which resulted in discontinuities in the hue space and exceptions in the color mapping code). 

Rewrote the RgbToHsv function to produce linear hue values and then implemented the color mapping as a table.  

It is, of course, subjective as to where the color space splits are, but it is an easily modifiable table that requires no code changes (just data) to tweak mappings if necessary. 

I changed the pink identifier to purple as the color on the device here definitely seems more purple than pink. 

Added a unit test